### PR TITLE
chore(fix): Fix issue when nil is passed as option to track

### DIFF
--- a/lib/vwo/utils/utility.rb
+++ b/lib/vwo/utils/utility.rb
@@ -25,6 +25,7 @@ class VWO
             # @param[Hash]
             # @return[Hash]
             def convert_to_symbol_hash(hashObject)
+                hashObject ||= {}
                 convertedHash = {}
                 hashObject.each do |key, value|
                     if valid_hash?(value)

--- a/tests/test_utility.rb
+++ b/tests/test_utility.rb
@@ -1,0 +1,43 @@
+# Copyright 2019-2021 Wingify Software Pvt. Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'json'
+require_relative '../lib/vwo/utils/utility'
+require 'test/unit'
+
+class UtilityTest < Test::Unit::TestCase
+  include VWO::Utils::Utility
+
+  def test_convert_to_symbol_hash_with_valid_hash
+    hashObject = { 'name': 'CUSTOM' }
+    expectation = { name: 'CUSTOM' }
+    result = convert_to_symbol_hash(hashObject)
+    assert_equal(expectation, result)
+  end
+
+  def test_convert_to_symbol_hash_with_empty_hash
+    hashObject = {}
+    expectation = {}
+    result = convert_to_symbol_hash(hashObject)
+    assert_equal(expectation, result)
+  end
+
+  def test_convert_to_symbol_hash_with_nil
+    hashObject = nil
+    expectation = {}
+    result = convert_to_symbol_hash(hashObject)
+    assert_equal(expectation, result)
+  end
+
+end


### PR DESCRIPTION
In this commit, we have fixed the issue when nil is passed as option to vwo_client_instance.track(campaign_key, user_id, goal_identifier, options)

- The track function is calling convert_to_symbol_hash method of lib/vwo/utils/utility.rb.
- When hashObject is nil in this function, each is raising an exception.
- This has been handled by assigning it to an empty hash if its nil.
- Since [https://developers.vwo.com/docs/ruby-track](url) says options is optional, this edge case should be handled as well. It was not causing an issue in an earlier version.